### PR TITLE
video4linux2: mxc: Fill in sequence number

### DIFF
--- a/drivers/media/platform/mxc/capture/mxc_v4l2_capture.c
+++ b/drivers/media/platform/mxc/capture/mxc_v4l2_capture.c
@@ -2659,6 +2659,12 @@ static void camera_callback(u32 mask, void *dev)
 
 	spin_lock(&cam->queue_int_lock);
 	spin_lock(&cam->dqueue_int_lock);
+
+                /* Also count frames when we do not have a buffer, so
+                 * we see when frames are missing
+                 */
+        cam->sequence++;
+
 	if (!list_empty(&cam->working_q)) {
 		do_gettimeofday(&cur_time);
 
@@ -2677,7 +2683,6 @@ static void camera_callback(u32 mask, void *dev)
 			 */
 			done_frame->buffer.timestamp = cur_time;
 			done_frame->buffer.sequence = cam->sequence;
-			cam->sequence++;
 
 			done_frame->buffer.flags |= V4L2_BUF_FLAG_DONE;
 			done_frame->buffer.flags &= ~V4L2_BUF_FLAG_QUEUED;

--- a/drivers/media/platform/mxc/capture/mxc_v4l2_capture.h
+++ b/drivers/media/platform/mxc/capture/mxc_v4l2_capture.h
@@ -136,6 +136,7 @@ typedef struct _cam_data {
 	void *rot_enc_bufs_vaddr[2];
 	int rot_enc_buf_size[2];
 	enum v4l2_buf_type type;
+	__u32 sequence;
 
 	/* still image capture */
 	wait_queue_head_t still_queue;


### PR DESCRIPTION
Hello again,

This is a little patch that - in addition to the timestamp field - also fills the sequence field in a VIDIOC_DQBUF ioctl, which was not implemented before. I reset the per-camera sequence counter on every open(2) on the device, if you have an idea for a better place please let me know. Also I am not sure which of the branches are currently under development, so for now I just fixed it in the 4.1.15 based branch. If you name me other branches then I could provide patches for them as well.

The sequence counter is now incremented also if there are no buffers available, so a user space application has the possibility to detect when there are missing frames.

Best regards,

Johannes
