### PR TITLE
media: imx8: mipi-csi: mxc-capture:  merge in fix from NXP for wrong …

### DIFF
--- a/drivers/media/platform/imx8/mxc-mipi-csi2_yav.c
+++ b/drivers/media/platform/imx8/mxc-mipi-csi2_yav.c
@@ -11,6 +11,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
+
+//#define DEBUG
 #include <linux/clk.h>
 #include <linux/delay.h>
 #include <linux/device.h>
@@ -406,11 +408,11 @@ static int mipi_csi2_set_fmt(struct v4l2_subdev *sd,
 
 	if (fmt->format.width * fmt->format.height > 720 * 480) {
 		csi2dev->hs_settle = rxhs_settle[1];
-		csi2dev->send_level = 0x300;
 	} else {
 		csi2dev->hs_settle = rxhs_settle[0];
-		csi2dev->send_level = 0x240;
 	}
+
+	csi2dev->send_level = 64;
 
 	return v4l2_subdev_call(sensor_sd, pad, set_fmt, NULL, fmt);
 }


### PR DESCRIPTION
Fixes issue where screen tearing occurs and the video buffer is misaligned with the screen resulting in the image wrapping around.   Caused by wrong buffer being used when csi restarted such as when resolution was changed.

Signed-off-by: Pat Kusbel <pat@kusbel.com>