### PR TITLE
drm: mxsfb: fix NULL pointer dereference

### DIFF
--- a/drivers/gpu/drm/mxsfb/mxsfb_kms.c
+++ b/drivers/gpu/drm/mxsfb/mxsfb_kms.c
@@ -673,7 +673,8 @@ static void mxsfb_plane_primary_atomic_update(struct drm_plane *plane,
 			bridge_state =
 				drm_atomic_get_new_bridge_state(state,
 								mxsfb->bridge);
-			bus_format = bridge_state->input_bus_cfg.format;
+			if (!IS_ERR_OR_NULL(bridge_state))
+				bus_format = bridge_state->input_bus_cfg.format;
 		}
 
 		/* If there is no bridge, use bus format from connector */


### PR DESCRIPTION
Similarly to commit 622c9a3a7868 ("drm: mxsfb: Fix NULL pointer dereference"), mxsfb should never be allowed to dereference the NULL pointer that drm_atomic_get_new_bridge_state is allowed to return.

```
Unable to handle kernel NULL pointer dereference at virtual address 0000000000000010
...
Call trace:
 mxsfb_plane_primary_atomic_update+0xec/0x260
 drm_atomic_helper_commit_planes+0xe8/0x20c
 drm_atomic_helper_commit_tail_rpm+0x5c/0xa0
 commit_tail+0xa0/0x180
 commit_work+0x14/0x20
 process_one_work+0x1c4/0x470
 worker_thread+0x70/0x434
 kthread+0x154/0x160
 ret_from_fork+0x10/0x20
```