### PR TITLE
arm64: dts: imx93-nvc-rpmsg: add rpmsg to imx93-nvc

### DIFF
--- a/arch/arm64/boot/dts/freescale/Makefile
+++ b/arch/arm64/boot/dts/freescale/Makefile
@@ -752,6 +752,7 @@ dtb-$(CONFIG_ARCH_MXC) += imx93-nitrogen-smarc.dtb \
 			  imx93-nitrogen-smarc-tevs.dtb \
 			  imx93-nitrogen-smarc-auo-b080uan01-dsi.dtb \
 			  imx93-nvc.dtb \
+			  imx93-nvc-rpmsg.dtb \
 
 dtb-$(CONFIG_ARCH_MXC) += imx91-nitrogen-smarc.dtb \
 

--- a/arch/arm64/boot/dts/freescale/imx93-nvc-rpmsg.dts
+++ b/arch/arm64/boot/dts/freescale/imx93-nvc-rpmsg.dts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: (GPL-2.0-or-later OR MIT)
+/*
+ * Copyright 2025 Ezurio LLC
+ *
+ */
+
+#include "imx93-nvc.dts"
+
+/ {
+	model = "Ezurio NVC (i.MX 93) + RPMSG";
+	compatible = "ezurio,imx93-nvc", "fsl,imx93";
+
+	reserved-memory {
+		m33_reserved: m33@a5000000 {
+			no-map;
+			reg = <0 0xa5000000 0 0x1000000>;
+		};
+
+		rsc_table: rsc-table@2021e000 {
+			reg = <0 0x2021e000 0 0x1000>;
+			no-map;
+		};
+
+		vdev0vring0: vdev0vring0@a4000000 {
+			reg = <0 0xa4000000 0 0x8000>;
+			no-map;
+		};
+
+		vdev0vring1: vdev0vring1@a4008000 {
+			reg = <0 0xa4008000 0 0x8000>;
+			no-map;
+		};
+
+		vdev1vring0: vdev1vring0@a4010000 {
+			reg = <0 0xa4010000 0 0x8000>;
+			no-map;
+		};
+
+		vdev1vring1: vdev1vring1@a4018000 {
+			reg = <0 0xa4018000 0 0x8000>;
+			no-map;
+		};
+
+		vdevbuffer: vdevbuffer@a4020000 {
+			compatible = "shared-dma-pool";
+			reg = <0 0xa4020000 0 0x100000>;
+			no-map;
+		};
+	};
+};
+
+&cm33 {
+	mbox-names = "tx", "rx", "rxdb";
+	mboxes = <&mu1 0 1
+		  &mu1 1 1
+		  &mu1 3 1>;
+	memory-region = <&vdevbuffer>, <&vdev0vring0>, <&vdev0vring1>,
+			<&vdev1vring0>, <&vdev1vring1>, <&rsc_table>,
+			<&m33_reserved>;
+	fsl,startup-delay-ms = <500>;
+	status = "okay";
+};
+
+&lpuart2 {
+	status = "disabled";
+};


### PR DESCRIPTION
Has corresponding change in meta-boundary to add `imx93-nvc-rpmsg.dtb` to `nitrogen93.conf`, along to recipes-kernel updating SRCREV of linux branch to this commit's hash. 